### PR TITLE
AudioElementSoundChannel: clamp volume range

### DIFF
--- a/lib/src/media/implementation/audio_element_sound_channel.dart
+++ b/lib/src/media/implementation/audio_element_sound_channel.dart
@@ -101,7 +101,7 @@ class AudioElementSoundChannel extends SoundChannel {
     } else {
       final volume1 = _soundTransform.volume;
       final volume2 = SoundMixer._audioElementMixer!.volume;
-      _audioElement!.volume = volume1 * volume2;
+      _audioElement!.volume = (volume1 * volume2).clamp(0.0, 1.0);
     }
   }
 


### PR DESCRIPTION
In some cases, the volume multiplication here can end up outside of the valid range of [0.0, 1.0]. Clamp the volume between 0.0 and 1.0; although this is likely an error in consumer code, due to async suspensions this can be essentially impossible to track down the exact cause, so better to handle it gracefully.